### PR TITLE
Add `school_id` to Majority and Classes Tables and Changed it's Logic Behavior, Implement Permission Middleware

### DIFF
--- a/app/Http/Controllers/ClassControllers.php
+++ b/app/Http/Controllers/ClassControllers.php
@@ -108,6 +108,7 @@ class ClassControllers extends Controller
         try {
             $data = $validator->validated();
             $data['updated_by'] = Auth::user()->name;
+            $data["school_id"] = Auth::user()->school_id;
             Kelas::where('uuid', $id)->update($data);
             return response()->json([
                 'success' => true,

--- a/app/Http/Controllers/ClassControllers.php
+++ b/app/Http/Controllers/ClassControllers.php
@@ -94,7 +94,7 @@ class ClassControllers extends Controller
             "class_code" => [
                 "required",
                 "max:255",
-                Rule::unique('majors')->ignore($id, 'uuid')
+                Rule::unique('majors')->ignore($id, 'uuid'),
             ],
             "class_name" => "required|string|max:255",
         ]);
@@ -105,7 +105,6 @@ class ClassControllers extends Controller
                 'message' => $validator->errors(),
             ], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
-        
         try {
             $data = $validator->validated();
             $data['updated_by'] = Auth::user()->name;

--- a/app/Http/Controllers/MajorityController.php
+++ b/app/Http/Controllers/MajorityController.php
@@ -60,6 +60,7 @@ class MajorityController extends Controller
         }
         try {
             $data = $validator->validated();
+            $data["school_id"] = Auth::user()->school_id;
             Major::create($data);
             return response()->json([
                 'success' => true,

--- a/app/Http/Controllers/MajorityController.php
+++ b/app/Http/Controllers/MajorityController.php
@@ -58,7 +58,6 @@ class MajorityController extends Controller
         }
         try {
             $data = $validator->validated();
-            $data['created_by'] = Auth::user()->name;
             Major::create($data);
             return response()->json([
                 'success' => true,
@@ -132,7 +131,6 @@ class MajorityController extends Controller
 
         try {
             $data = $validator->validated();
-            $data['updated_by'] = Auth::user()->name;
 
             Major::where('uuid', $id)->update($data);
 

--- a/app/Http/Controllers/PermissionController.php
+++ b/app/Http/Controllers/PermissionController.php
@@ -15,6 +15,16 @@ use Illuminate\Http\JsonResponse;
  */
 class PermissionController extends Controller
 {
+    public function __construct()
+    {
+        // Permission Middleware
+        $this->middleware(['permission:view-permission'])->only('index');
+        $this->middleware(['permission:view-permission'])->only('show');
+        $this->middleware(['permission:create-permission'])->only('store');
+        $this->middleware(['permission:update-permission'])->only('update');
+        $this->middleware(['permission:delete-permission'])->only('destroy');
+    }
+
     /**
      * @return JsonResponse
      *

--- a/app/Http/Controllers/RoleControllers.php
+++ b/app/Http/Controllers/RoleControllers.php
@@ -13,6 +13,16 @@ use Illuminate\Http\JsonResponse;
  */
 class RoleControllers extends Controller
 {
+    public function __construct()
+    {
+        // Permission Middleware
+        $this->middleware(['permission:view-roles'])->only('index');
+        $this->middleware(['permission:view-roles'])->only('show');
+        $this->middleware(['permission:create-roles'])->only('store');
+        $this->middleware(['permission:update-roles'])->only('update');
+        $this->middleware(['permission:delete-roles'])->only('destroy');
+    }
+
     /**
      * @return JsonResponse
      *

--- a/app/Http/Controllers/SchoolControllers.php
+++ b/app/Http/Controllers/SchoolControllers.php
@@ -46,7 +46,7 @@ class SchoolControllers extends Controller
             return response()->json([
                 'success' => true,
                 'message' => 'Daftar Data Sekolah',
-                'data' => $schools
+                'data' => SchoolResource::collection($schools),
             ], Response::HTTP_OK);
 
         } catch (\Exception $e) {
@@ -233,5 +233,5 @@ class SchoolControllers extends Controller
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
-    
+
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Traits\CreatedBy;
 use Illuminate\Http\Request;
 use App\Exports\UsersExport;
 use App\Imports\UsersImport;
@@ -19,7 +20,7 @@ class UsersController extends Controller
         $search = $request->query('name');
         $rows = $request['rows'] != 0 ? $request['rows'] : 5;
         $roles = $request->query("roles") ? explode(',', $request->query("roles")) : [];
-        $users = User::where('name', 'LIKE', "%$search%")->when(count($roles) != 0, function ($query) use ($roles) { 
+        $users = User::where('name', 'LIKE', "%$search%")->when(count($roles) != 0, function ($query) use ($roles) {
             $query->whereHas("roles", function ($query) use ($roles) {
                 $query->whereIn("name", $roles);
             });
@@ -54,14 +55,12 @@ class UsersController extends Controller
                     $rules['school_id'] = 'nullable|exists:school,uuid';
                     $rules['major_id'] = 'required|exists:majors,uuid';
                     $rules['class_id'] = 'nullable|exists:classes,uuid';
-                    $rules['partner_id'] = 'nullable|exists:partners,uuid';
                     break;
 
                 case 'Student':
                     $rules['school_id'] = 'nullable|exists:school,uuid';
                     $rules['major_id'] = 'required|exists:majors,uuid';
                     $rules['class_id'] = 'required|exists:classes,uuid';
-                    $rules['partner_id'] = 'nullable|exists:partners,uuid';
                     break;
 
                 // no additional validation for the roles below, use default rule
@@ -73,7 +72,6 @@ class UsersController extends Controller
                     $rules['school_id'] = 'nullable|exists:school,uuid';
                     $rules['major_id'] = 'nullable|exists:majors,uuid';
                     $rules['class_id'] = 'nullable|exists:classes,uuid';
-                    $rules['partner_id'] = 'nullable|exists:partners,uuid';
                     break;
 
                 default:
@@ -97,12 +95,10 @@ class UsersController extends Controller
             $user->phone_number = $validatedData['phone_number'];
             $user->password = bcrypt($validatedData['password']);
             $user->nip_nisn = $validatedData['nip_nisn'] ?? null;
-            $user->created_by = auth()->id();  // admin id as creator
             $user->assignRole($validatedData['role']);
             $user->school_id = $validatedData['school_id'];
             $user->major_id = $validatedData['major_id'] ?? null;
             $user->class_id = $validatedData['class_id'] ?? null;
-            $user->partner_id = $validatedData['partner_id'] ?? null;
             $user->save();
 
             return response()->json([
@@ -151,14 +147,12 @@ class UsersController extends Controller
                     $rules['school_id'] = 'nullable|exists:school,uuid';
                     $rules['major_id'] = 'required|exists:majors,uuid';
                     $rules['class_id'] = 'nullable|exists:classes,uuid';
-                    $rules['partner_id'] = 'nullable|exists:partners,uuid';
                     break;
 
                 case 'Student':
                     $rules['school_id'] = 'nullable|exists:school,uuid';
                     $rules['major_id'] = 'required|exists:majors,uuid';
                     $rules['class_id'] = 'required|exists:classes,uuid';
-                    $rules['partner_id'] = 'nullable|exists:partners,uuid';
                     break;
 
                 // no additional validation for the roles below, use default rule
@@ -170,7 +164,6 @@ class UsersController extends Controller
                     $rules['school_id'] = 'nullable|exists:school,uuid';
                     $rules['major_id'] = 'nullable|exists:majors,uuid';
                     $rules['class_id'] = 'nullable|exists:classes,uuid';
-                    $rules['partner_id'] = 'nullable|exists:partners,uuid';
                     break;
 
                 default:
@@ -195,11 +188,9 @@ class UsersController extends Controller
 
             $user->nip_nisn = $validatedData['nip_nisn'] ?? null;
             $user->assignRole($validatedData['role']);
-            $user->updated_by = auth()->id(); // admin id as creator
             $user->school_id = $validatedData['school_id'];
             $user->major_id = $validatedData['major_id'] ?? null;
             $user->class_id = $validatedData['class_id'] ?? null;
-            $user->partner_id = $validatedData['partner_id'] ?? null;
             $user->save();
 
             return response()->json([
@@ -226,7 +217,6 @@ class UsersController extends Controller
             $user = User::findOrFail($id);
 
             // set kolom deleted_by dan soft delete
-            $user->deleted_by = auth()->id(); // admin id as deleter
 
             // delete user
             $user->delete();

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,8 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
     ];
 }

--- a/app/Models/Kelas.php
+++ b/app/Models/Kelas.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Facades\Auth;
 
 class Kelas extends Model
 {
@@ -44,13 +43,6 @@ class Kelas extends Model
                 $majorCode = $major->major_code;
                 $kelas->class_code = "{$majorCode}-" . str_pad(($major->classes()->count() + 1), 2, '0', STR_PAD_LEFT);
             }
-        });
-    }
-
-    protected static function booted(): void
-    {
-        static::creating(function ($model) {
-            $model->school_id = Auth::user()->school_id;
         });
     }
 }

--- a/app/Models/Kelas.php
+++ b/app/Models/Kelas.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\CreatedBy;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Kelas extends Model
 {
-    use HasFactory, HasUuids, SoftDeletes;
+    use HasFactory, HasUuids, SoftDeletes, CreatedBy;
 
     protected $table = 'classes';
     protected $primaryKey = 'uuid';
@@ -37,7 +38,7 @@ class Kelas extends Model
         parent::boot();
 
         static::creating(function ($kelas) {
-            $major = Major::find($kelas->major); 
+            $major = Major::find($kelas->major);
             if ($major) {
                 $majorCode = $major->major_code;
                 $kelas->class_code = "{$majorCode}-" . str_pad(($major->classes()->count() + 1), 2, '0', STR_PAD_LEFT);

--- a/app/Models/Kelas.php
+++ b/app/Models/Kelas.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Auth;
 
 class Kelas extends Model
 {
@@ -43,6 +44,13 @@ class Kelas extends Model
                 $majorCode = $major->major_code;
                 $kelas->class_code = "{$majorCode}-" . str_pad(($major->classes()->count() + 1), 2, '0', STR_PAD_LEFT);
             }
+        });
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function ($model) {
+            $model->school_id = Auth::user()->school_id;
         });
     }
 }

--- a/app/Models/Major.php
+++ b/app/Models/Major.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Auth;
 
 class Major extends Model
 {
@@ -46,6 +47,13 @@ class Major extends Model
             } else {
                 $model->major_code = 'MJ-001';
             }
+        });
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function ($model) {
+            $model->school_id = Auth::user()->school_id;
         });
     }
 }

--- a/app/Models/Major.php
+++ b/app/Models/Major.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Facades\Auth;
 
 class Major extends Model
 {
@@ -47,13 +46,6 @@ class Major extends Model
             } else {
                 $model->major_code = 'MJ-001';
             }
-        });
-    }
-
-    protected static function booted(): void
-    {
-        static::creating(function ($model) {
-            $model->school_id = Auth::user()->school_id;
         });
     }
 }

--- a/app/Models/Major.php
+++ b/app/Models/Major.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\CreatedBy;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Major extends Model
 {
-    use HasFactory, HasUuids, SoftDeletes;
+    use HasFactory, HasUuids, SoftDeletes, CreatedBy;
 
     protected $primaryKey = 'uuid';
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\CreatedBy;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 use Tymon\JWTAuth\Contracts\JWTSubject;
@@ -14,7 +15,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable implements JWTSubject
 {
-    use HasApiTokens, HasFactory, Notifiable, HasRoles, HasUuids, SoftDeletes;
+    use HasApiTokens, HasFactory, Notifiable, HasRoles, HasUuids, SoftDeletes, CreatedBy;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Traits\CreatedBy;
-use Illuminate\Support\Facades\Auth;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 use Tymon\JWTAuth\Contracts\JWTSubject;
@@ -114,12 +113,5 @@ class User extends Authenticatable implements JWTSubject
     public function partners()
     {
         return $this->belongsToMany(Partner::class, 'mentor_partner', 'user_id', 'partner_id');
-    }
-
-    protected static function booted(): void
-    {
-        static::creating(function ($model) {
-            $model->school_id = Auth::user()->school_id;
-        });
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Traits\CreatedBy;
+use Illuminate\Support\Facades\Auth;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 use Tymon\JWTAuth\Contracts\JWTSubject;
@@ -113,5 +114,12 @@ class User extends Authenticatable implements JWTSubject
     public function partners()
     {
         return $this->belongsTo(Partner::class, 'mentor_partner', 'user_id', 'partner_id');
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function ($model) {
+            $model->school_id = Auth::user()->school_id;
+        });
     }
 }

--- a/app/Providers/BlueprintMacroServiceProvider.php
+++ b/app/Providers/BlueprintMacroServiceProvider.php
@@ -20,10 +20,10 @@ class BlueprintMacroServiceProvider extends ServiceProvider
         });
 
         Blueprint::macro('dropCreatedBy', function () {
-            $this->dropColumn(['created_by', 'updated_by', 'deleted_by']);
             $this->dropForeign(['created_by']);
             $this->dropForeign(['updated_by']);
             $this->dropForeign(['deleted_by']);
+            $this->dropColumn(['created_by', 'updated_by', 'deleted_by']);
         });
     }
 }

--- a/database/migrations/2024_10_08_130824_update_createdby_user.php
+++ b/database/migrations/2024_10_08_130824_update_createdby_user.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table("users", function (Blueprint $table) {
+            $table->dropColumn("created_by");
+            $table->dropColumn("updated_by");
+            $table->dropColumn("deleted_by");
+        });
+        Schema::table("users", function (Blueprint $table) {
+            $table->createdBy();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table("users", function (Blueprint $table) {
+            $table->dropCreatedBy();
+        });
+    }
+};

--- a/database/migrations/2024_10_10_080821_add_schoolid_to_classes_majority_table.php
+++ b/database/migrations/2024_10_10_080821_add_schoolid_to_classes_majority_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('classes', function (Blueprint $table) {
+            $table->uuid('school_id')->after('class_name');
+            $table->foreign('school_id')->references('uuid')->on('school');
+            $table->createdBy();
+        });
+        Schema::table('majors', function (Blueprint $table) {
+            $table->dropColumn('created_by');
+            $table->dropColumn('updated_by');
+            $table->dropColumn('deleted_by');
+        });
+        Schema::table('majors', function (Blueprint $table) {
+            $table->uuid('school_id')->after('major_name');
+            $table->foreign('school_id')->references('uuid')->on('school');
+            $table->createdBy();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('classes', function (Blueprint $table) {
+            $table->dropForeign(['school_id']);
+            $table->dropColumn('school_id');
+            $table->dropCreatedBy();
+        });
+
+        Schema::table('majors', function (Blueprint $table) {
+            $table->dropForeign(['school_id']);
+            $table->dropColumn('school_id');
+            $table->dropCreatedBy();
+        });
+    }
+};

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -3,11 +3,18 @@
 namespace Database\Seeders;
 
 use App\Models\Permission;
+use App\Models\Role;
 use Illuminate\Database\Seeder;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class PermissionSeeder extends Seeder
 {
+    private function createPermissions(array $permissions): void
+    {
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission]);
+        }
+    }
     /**
      * Run the database seeds.
      */
@@ -18,11 +25,30 @@ class PermissionSeeder extends Seeder
             'edit-users',
             'delete-users',
             'view-reports',
-            'manage-roles',
         ];
 
-        foreach ($permissions as $permission) {
-            Permission::firstOrCreate(['name' => $permission]);
-        }
+        $this->createPermissions($permissions);
+
+        $rolesPermissions = [
+            'view-roles',
+            'create-roles',
+            'update-roles',
+            'delete-roles'
+        ];
+
+        $this->createPermissions($rolesPermissions);
+
+        $permissionsPermissions = [
+            'view-permissions',
+            'create-permissions',
+            'update-permissions',
+            'delete-permissions'
+        ];
+
+        $this->createPermissions($permissionsPermissions);
+
+        $role = Role::where('name', 'Super Administrator')->first();
+        $role->givePermissionTo($permissions, $rolesPermissions, $permissionsPermissions);
+//        $role->revokePermissionTo($rolesPermissions);
     }
 }


### PR DESCRIPTION
- Added `school_id` field to the `majors` and `classes` tables and adjusted related models.
- Implemented permission checks via middleware for the `PermissionController` and `RoleController` to restrict access based on user roles.
- Fixed the `CreatedBy` trait to improve tracking of `created_by`, `updated_by`, and `deleted_by` fields.
- Adjusted migration files and added the ability to drop the `created_by`, `updated_by`, and `deleted_by` columns.
- Updated database seeder to add role and permission management for the new permission checks.